### PR TITLE
Bug Correction : custom scan engine dump and load

### DIFF
--- a/web/reNgine/common_func.py
+++ b/web/reNgine/common_func.py
@@ -35,6 +35,7 @@ DISCORD_WEBHOOKS_CACHE = redis.Redis.from_url(CELERY_BROKER_URL)
 #------------------#
 def dump_custom_scan_engines(results_dir):
     """Dump custom scan engines to YAML files.
+
     Args:
         results_dir (str): Results directory (will be created if non-existent).
     """
@@ -48,6 +49,7 @@ def dump_custom_scan_engines(results_dir):
 def load_custom_scan_engines(results_dir):
     """Load custom scan engines from YAML files. The filename without .yaml will
     be used as the engine name.
+
     Args:
         results_dir (str): Results directory containing engines configs.
     """


### PR DESCRIPTION
python3 manage.py loadcustomengines
python3 manage.py dumpcustomengines

When using these functions the dumped/loaded custom engines format is not preserved. The new code now dumped the custom engines in the right format and when loading also.